### PR TITLE
Accommodate MappingFailedException to Protobuf Source Mapping

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -203,7 +203,7 @@
         </plugins>
     </build>
     <properties>
-        <siddhi.version>5.1.13</siddhi.version>
+        <siddhi.version>5.1.14</siddhi.version>
         <mavan.findbugsplugin.exclude.file>findbugs-exclude.xml</mavan.findbugsplugin.exclude.file>
         <siddhi.version.range>[5.0.0,6.0.0)</siddhi.version.range>
         <log4j.version>1.2.17.wso2v1</log4j.version>


### PR DESCRIPTION
## Purpose
> We introduced error handling for Siddhi in https://github.com/siddhi-io/siddhi/pull/1662, where a new type of exception called `MappingFailedException` was introduced. This PR is to accommodate the exception into the current implementation of Protobuf source mapping.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Related PRs
> https://github.com/siddhi-io/siddhi/pull/1662